### PR TITLE
fix: Install dependencies.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -26,12 +26,16 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-          # cache: 'yarn'
+          cache: 'yarn'
 
-      - run: cp -rf ./packages/default-vsf ./src/modules/
+      - name: Copy default vue store front
+        run: cp -rf ./packages/default-vsf ./src/modules/
+
+      - name: Enable https to install packages
+        run: git config --global url."https://".insteadOf git://
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn ci
 
       - name: Run test
         run: yarn lint

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -30,13 +30,16 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-          # cache: 'yarn'
+          cache: 'yarn'
 
       - name: Copy default vue store front
         run: cp -rf ./packages/default-vsf ./src/modules/
 
+      - name: Enable https to install packages
+        run: git config --global url."https://".insteadOf git://
+
       - name: Install node dependencies
-        run: yarn install 
+        run: yarn ci
 
       - name: Run test
         run: yarn lint

--- a/config/default.json
+++ b/config/default.json
@@ -1,7 +1,7 @@
 {
   "server": {
     "host": "localhost",
-    "port": 8080,
+    "port": 8085,
     "searchEngine": "elasticsearch",
     "useOutputCacheTagging": false,
     "useOutputCache": false,

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "node": ">=10"
   },
   "scripts": {
+    "ci": "yarn install --frozen-lockfile",
     "dev": "nodemon",
     "dev:inspect": "nodemon --exec \"node --inspect -r ts-node/register src\"",
     "build": "npm run -s build:packages && npm run -s build:code && npm run -s build:copy:graphql && npm run -s build:copy:schema",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,10 +24,10 @@
     striptags "^3.0.1"
     word-wrap "^1.2.1"
 
-"@adempiere/grpc-api@3.0.3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@adempiere/grpc-api/-/grpc-api-3.0.3.tgz#2ae1ef0a5c03d2f9fe00bd72e5f32a589d786eee"
-  integrity sha512-Ppwz4msOXfH+rk7ageClZ+nB87JFcsQDxDJUAMMo4mWVIVrpp2f/mheJJ3YjiBLRGWP89/pzEiBn6lbbbdbMgA==
+"@adempiere/grpc-api@3.0.5":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@adempiere/grpc-api/-/grpc-api-3.0.4.tgz#e262e2e4e9c1d3ef7c5e3ad7042d84fa57734bbc"
+  integrity sha512-/PgyhNtxzh07Uxb6ki2U/ixO7O3JEwgLL54xo0Lvae7GvBOSzdYOinmKD6DHJSntM161Whr/MOlFYwd4fb4EhQ==
   dependencies:
     "@grpc/grpc-js" "1.6.7"
     google-protobuf "3.20.1"


### PR DESCRIPTION


### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

* Fixed bug due to version difference in package.json not in yarn.lock
The docker image is generated with version 14, but in the github actions it is compiled with version 12.
* Change of default port from 8080 to 8085, since it is the one that is configured in the docker image and in the front it looks to replace that port.
* Enable instance of the git:// protocol to https:// to avoid errors when installing dependencies.
* Added `ci` (continuous integration) script for installation in the github actions, avoiding to alter the yarn.lock file ensuring that the dependencies will be installed exactly as set in that file.



### Screenshots of visual changes before/after (if there are any)
<!-- if you made any changes in the UI, please provide before/after screenshots -->
![Screenshot_20220713_142219](https://user-images.githubusercontent.com/20288327/178804090-857bba9a-19de-436d-a6ed-cc343d0848d2.png)
