### PR TITLE
fix: Yarn.lock downgrade 3.0.5 to 3.0.4

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -24,7 +24,7 @@
     striptags "^3.0.1"
     word-wrap "^1.2.1"
 
-"@adempiere/grpc-api@3.0.5":
+"@adempiere/grpc-api@3.0.4":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@adempiere/grpc-api/-/grpc-api-3.0.4.tgz#e262e2e4e9c1d3ef7c5e3ad7042d84fa57734bbc"
   integrity sha512-/PgyhNtxzh07Uxb6ki2U/ixO7O3JEwgLL54xo0Lvae7GvBOSzdYOinmKD6DHJSntM161Whr/MOlFYwd4fb4EhQ==


### PR DESCRIPTION

Because version 3.0.5 was not released it generated an error when trying to install it, in this case we downgrade to version 3.0.4 to correctly generate the yarn.lock.



### Screenshots of visual changes before/after (if there are any)

![Screenshot_20220714_090421](https://user-images.githubusercontent.com/20288327/178989024-97861cfb-39f8-4a57-b992-d78b0e228173.png)


![Screenshot_20220714_085320](https://user-images.githubusercontent.com/20288327/178988903-2f0193e3-9cde-48ff-a1b1-c18ae6396682.png)

![Screenshot_20220714_090401](https://user-images.githubusercontent.com/20288327/178989036-b1a34b02-33d0-4abc-bf14-e2f5c5b371f5.png)

