### PR TITLE
fix: Extensions cannot get with docker container.

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -268,6 +268,7 @@
     },
     "adempiereApi": {
       "registeredExtensions": [
+        "adempiere",
         "adempiere/dictionary",
         "adempiere/common",
         "adempiere/common/api",

--- a/docker/adempiere-api/default.json
+++ b/docker/adempiere-api/default.json
@@ -306,6 +306,7 @@
     },
     "adempiereApi": {
       "registeredExtensions": [
+        "adempiere",
         "adempiere/dictionary",
         "adempiere/common",
         "adempiere/common/api",
@@ -327,7 +328,15 @@
         "adempiere/user-interface/component/record-access",
         "adempiere/user-interface/component/notes",
         "adempiere/user-interface/component/translation",
-        "adempiere/form/addons/point-of-sales"
+        "adempiere/form/addons/point-of-sales",
+        "adempiere/grid",
+        "adempiere/business-partner",
+        "adempiere/in-out",
+        "adempiere/invoice",
+        "adempiere/order",
+        "adempiere/payment",
+        "adempiere/invoice",
+        "adempiere/product"
       ],
       "images": {
         "baseUrl": "API_URL_IMAGES",

--- a/src/modules/adempiere-api/api/extensions/adempiere/index.js
+++ b/src/modules/adempiere-api/api/extensions/adempiere/index.js
@@ -1,0 +1,45 @@
+/**
+ * ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ * Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Router } from 'express';
+import { version, dependencies } from '../../../../../../package.json';
+
+module.exports = ({ config }) => {
+  const api = Router();
+
+  /**
+   * GET Registered Extensions on ADempiere-API
+   *
+   * Details:
+   */
+  api.get('/', (req, res) => {
+    res.json({
+      code: 200,
+      result: {
+        name: 'adempiereApi',
+        version,
+        description: 'Registered Extensions on ADempiere-API',
+        '@adempiere/grpc-api': dependencies['@adempiere/grpc-api'],
+        '@adempiere/grpc-web-store-api': dependencies['@adempiere/grpc-web-store-api'],
+        registeredExtensions: config.get('modules.adempiereApi.registeredExtensions')
+      }
+    });
+  });
+
+  return api;
+};


### PR DESCRIPTION
### Related issues
<!--  Put related issue number this PR is closing. For example #123 -->

### Short description and why it's useful

The new extensions added, are not accessible with a docker container, this is because the configuration file for docker is different from the default configuration file, here are the extensions not found:

- "adempiere/grid"
- "adempiere/business-partner"
- "adempiere/in-out"
- "adempiere/invoice"
- "adempiere/order"
- "adempiere/payment"
- "adempiere/invoice"
- "adempiere/product"

### Screenshots of visual changes before/after (if there are any)
Before this changes:

![Screenshot_20220801_111021](https://user-images.githubusercontent.com/20288327/182187522-b9955b16-a805-43d1-8d2f-e94acf151d25.png)

After this changes:

![Screenshot_20220801_111038](https://user-images.githubusercontent.com/20288327/182187519-9f275e3d-0aed-4a1d-ae72-3ac23533e0b7.png)


#### Additional context:
Add extension info on `api/adempiere`:

http://localhost:8085/api/adempiere

![Screenshot_20220801_114318](https://user-images.githubusercontent.com/20288327/182187732-281af98b-8911-4ddd-b85e-61f40cefb797.png)




