### PR TITLE
fixed: Callout set value and old value with value type.

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "license": "MIT",
   "dependencies": {
     "@2fd/graphdoc": "^2.4.0",
-    "@adempiere/grpc-api": "3.4.3",
+    "@adempiere/grpc-api": "3.4.4",
     "@adempiere/grpc-web-store-api": "1.5.7",
     "@elastic/elasticsearch": "7.14.0",
     "@google-cloud/storage": "^3.0.3",

--- a/src/modules/adempiere-api/api/extensions/adempiere/user-interface/window/index.js
+++ b/src/modules/adempiere-api/api/extensions/adempiere/user-interface/window/index.js
@@ -1,3 +1,18 @@
+/************************************************************************************
+ * Copyright (C) 2012-2022 E.R.P. Consultores y Asociados, C.A.                     *
+ * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com                     *
+ * This program is free software: you can redistribute it and/or modify             *
+ * it under the terms of the GNU General Public License as published by             *
+ * the Free Software Foundation, either version 2 of the License, or                *
+ * (at your option) any later version.                                              *
+ * This program is distributed in the hope that it will be useful,                  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
+ * GNU General Public License for more details.                                     *
+ * You should have received a copy of the GNU General Public License                *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.            *
+ ************************************************************************************/
+
 import { Router } from 'express';
 import {
   convertRecordReferenceInfoFromGRPC,
@@ -8,10 +23,11 @@ import {
   convertLookupFromGRPC,
   convertCalloutFromGRPC
 } from '@adempiere/grpc-api/lib/convertBusinessData';
+
 module.exports = ({ config }) => {
-  let api = Router();
+  const api = Router();
   const ServiceApi = require('@adempiere/grpc-api')
-  let service = new ServiceApi(config)
+  const service = new ServiceApi(config)
 
   /**
    * GET Context Information Value
@@ -386,11 +402,12 @@ module.exports = ({ config }) => {
         tabUuid: req.body.tab_uuid,
         callout: req.body.callout,
         columnName: req.body.column_name,
+        valueType: req.body.value_type,
         oldValue: req.body.old_value,
         value: req.body.value,
         windowNo: req.body.window_no,
         contextAttributes: req.body.context_attributes
-      }, function (err, response) {
+      }, (err, response) => {
         if (response) {
           res.json({
             code: 200,

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,10 +24,10 @@
     striptags "^3.0.1"
     word-wrap "^1.2.1"
 
-"@adempiere/grpc-api@3.4.3":
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/@adempiere/grpc-api/-/grpc-api-3.4.3.tgz#ea602d81adb06f5238067182ae773c2e0493b451"
-  integrity sha512-eSgxLuQyHw82VIiwPMzFOs7erNvzkEITeLCWNh3Te4Caz2VaHpLcr2jIL3XjyeqKe48MVUeWKUgkD61pf2h+Tg==
+"@adempiere/grpc-api@3.4.4":
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/@adempiere/grpc-api/-/grpc-api-3.4.4.tgz#718e2e8c62a7e499633f751c66921e3d44de5769"
+  integrity sha512-FMhNxbrcWoDX+uKQs7/5qAHmp1cnpcNexACAu0rbHybmzeOL7fBYj4BnMKmoP5xfMHeWLHchCTdw25HIOJM1Vg==
   dependencies:
     "@grpc/grpc-js" "1.7.0"
     google-protobuf "3.21.0"


### PR DESCRIPTION


Request:

http://0.0.0.0:8085/api/adempiere/user-interface/window/run-callout?token=e4582708-8cd1-47b8-9fba-00644bf9fa20&language=es

Response:

```json
{
	"code": 200,
	"result": {
		"result": "",
		"values": {
			"DeliveryRule": "R",
			"DocumentNo": "<30000>",
			"HasCharges": false,
			"IsDropShip": false,
			"OrderType": "PR",
			"PaymentRule": "P"
		}
	}
}
```


#### Additional context
Depends on https://github.com/solop-develop/gRPC-API/pull/45