### PR TITLE
fix: Confirmed optional flag.

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "license": "MIT",
   "dependencies": {
     "@2fd/graphdoc": "^2.4.0",
-    "@adempiere/grpc-api": "3.5.0",
+    "@adempiere/grpc-api": "3.5.1",
     "@adempiere/grpc-web-store-api": "1.5.7",
     "@elastic/elasticsearch": "7.14.0",
     "@google-cloud/storage": "^3.0.3",

--- a/src/modules/adempiere-api/api/extensions/adempiere/form/addons/time-control/index.js
+++ b/src/modules/adempiere-api/api/extensions/adempiere/form/addons/time-control/index.js
@@ -63,7 +63,7 @@ module.exports = ({ config }) => {
         resourceTypeUuid: req.body.resource_type_uuid,
         name: req.body.name,
         description: req.body.description,
-        isOnlyConfirmed: req.body.is_only_confirmed,
+        confirmed: req.body.confirmed,
         isWaitingForOrdered: req.body.is_waiting_for_ordered,
         dateFrom: req.body.date_from,
         dateTo: req.body.date_to,

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,10 +24,10 @@
     striptags "^3.0.1"
     word-wrap "^1.2.1"
 
-"@adempiere/grpc-api@3.5.0":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@adempiere/grpc-api/-/grpc-api-3.5.0.tgz#0b58d9e0367ee9d6333b9ae47713ce97fb9426cc"
-  integrity sha512-1OYqlAuKlpC6/3b01triTLVA0FIZo750MierIgYsfcZ6QmazllsiZs4cc8hCI7JgJuJJsgHwfeX3uffBxKY9aw==
+"@adempiere/grpc-api@3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@adempiere/grpc-api/-/grpc-api-3.5.1.tgz#26827fc2492de4ae2f7ebce5d572b3c3324aa349"
+  integrity sha512-x+bvdttUoGwgK8JP++ubRFB16aG/WMQlDc36YshBlnPV/v8GdesbsbOljzynhEk6JBhqlAqVXdw8vmiC8tUKqw==
   dependencies:
     "@grpc/grpc-js" "1.7.0"
     google-protobuf "3.21.0"


### PR DESCRIPTION

Now you can list confirmed records, unconfirmed records, and both, previously the search was exclusive.


https://user-images.githubusercontent.com/20288327/195099025-4c4c5377-a43e-4b89-9ee7-9edf02e30219.mp4



Depends on https://github.com/solop-develop/gRPC-API/pull/53