### PR TITLE
fix: Search text with like as default operator.

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "license": "MIT",
   "dependencies": {
     "@2fd/graphdoc": "^2.4.0",
-    "@adempiere/grpc-api": "3.6.1",
+    "@adempiere/grpc-api": "3.6.2",
     "@adempiere/grpc-web-store-api": "1.5.7",
     "@elastic/elasticsearch": "7.14.0",
     "@google-cloud/storage": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,10 +24,10 @@
     striptags "^3.0.1"
     word-wrap "^1.2.1"
 
-"@adempiere/grpc-api@3.6.1":
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/@adempiere/grpc-api/-/grpc-api-3.6.1.tgz#9f77b79a0e00174247dfccd493ac57c344361e73"
-  integrity sha512-U1e+soeKLk0BPE54GApDvYobdGvPCM0+QJJjuaMznIcWpvpditSyYk9+Y59s0SujnQpx96SrPFIFxpfYNeA4Vg==
+"@adempiere/grpc-api@3.6.2":
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/@adempiere/grpc-api/-/grpc-api-3.6.2.tgz#f0682e50cfcc67d7e7ebc866b7c129953960aac2"
+  integrity sha512-4EoSVMbAfr5W2OOUg5EwZuBmq1DmZFq7R54que/dUrZDAbfFNX84RZiBxpgmbYiZf0t7nQm4BfBSKhdHLYGSiQ==
   dependencies:
     "@grpc/grpc-js" "1.7.0"
     google-protobuf "3.21.0"


### PR DESCRIPTION
When a search is made for a text field and the LIKE operator was not sent, it takes EQUAL as the default operator, so an exact search had to be made.

A default operator called VOID is added, which when set, searches for the default operator according to the display type, for number type fields the EQUAL, for text type fields the LIKE operator.


#### Screenshot

https://user-images.githubusercontent.com/20288327/201457227-3583d223-1404-4c01-8f82-6983d72d3658.mp4



#### Additional context
Fixes https://github.com/solop-develop/frontend-core/issues/462
Depends on https://github.com/solop-develop/backend/pull/149
Depends on https://github.com/solop-develop/gRPC-API/pull/61
