### PR TITLE
fix: List document status.

### DIFF
--- a/src/modules/adempiere-api/api/extensions/adempiere/workflow/index.js
+++ b/src/modules/adempiere-api/api/extensions/adempiere/workflow/index.js
@@ -18,7 +18,7 @@ import {
   getWorkflowDefinitionFromGRPC,
   getWorkflowActivityFromGRPC,
   getDocumentActionFromGRPC,
-  gettDocumentStatusFromGRPC
+  getDocumentStatusFromGRPC
 } from '@adempiere/grpc-api/src/utils/workflowFromGRPC';
 import { convertProcessLogFromGRPC } from '@adempiere/grpc-api/lib/convertBaseDataType';
 
@@ -298,7 +298,7 @@ module.exports = ({ config }) => {
               record_count: response.getRecordCount(),
               next_page_token: response.getNextPageToken(),
               records: response.getDocumentStatusesList().map(documentStatus => {
-                return gettDocumentStatusFromGRPC(documentStatus)
+                return getDocumentStatusFromGRPC(documentStatus)
               })
             }
           })


### PR DESCRIPTION
#### Request 
http://localhost:8085/api/adempiere/workflow/document-statuses?uuid=d4bd6536-0416-4fa9-9470-fe33e0ac3125&table_name=C_Order&page_token=&page_size=0&token=90eaae44-97be-4355-b275-a5b209ce5bb2&language=en&ts=1675092162155

#### Response

Before this changes
```log
error: uncaughtException: workflowFromGRPC_1.gettDocumentStatusFromGRPC is not a function date=Mon Jan 30 2023 11:40:40 GMT-0400 (hora de Venezuela), pid=7984, uid=1000, gid=1000, cwd=/home/edwin/workspace/solop/proxy-adempiere-api, execPath=/home/edwin/.nvm/versions/node/v14.21.2/bin/node, version=v14.21.2, argv=[/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/.bin/ts-node, /home/edwin/workspace/solop/proxy-adempiere-api/src], rss=390189056, heapTotal=270176256, heapUsed=259825264, external=6988460, arrayBuffers=4571470, loadavg=[1.91, 1.63, 1.51], uptime=7310.73, trace=[column=24, file=/home/edwin/workspace/solop/proxy-adempiere-api/src/modules/adempiere-api/api/extensions/adempiere/workflow/index.js, function=null, line=301, method=null, native=false, column=null, file=null, function=Array.map, line=null, method=map, native=false, column=59, file=/home/edwin/workspace/solop/proxy-adempiere-api/src/modules/adempiere-api/api/extensions/adempiere/workflow/index.js, function=Object.callback, line=300, method=callback, native=false, column=28, file=/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/client.ts, function=Object.onReceiveStatus, line=354, method=onReceiveStatus, native=false, column=34, file=/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/client-interceptors.ts, function=Object.onReceiveStatus, line=462, method=onReceiveStatus, native=false, column=48, file=/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/client-interceptors.ts, function=Object.onReceiveStatus, line=424, method=onReceiveStatus, native=false, column=24, file=/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/call-stream.ts, function=null, line=334, method=null, native=false, column=11, file=internal/process/task_queues.js, function=processTicksAndRejections, line=77, method=null, native=false], stack=[TypeError: workflowFromGRPC_1.gettDocumentStatusFromGRPC is not a function,     at /home/edwin/workspace/solop/proxy-adempiere-api/src/modules/adempiere-api/api/extensions/adempiere/workflow/index.js:301:24,     at Array.map (<anonymous>),     at Object.callback (/home/edwin/workspace/solop/proxy-adempiere-api/src/modules/adempiere-api/api/extensions/adempiere/workflow/index.js:300:59),     at Object.onReceiveStatus (/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/client.ts:354:28),     at Object.onReceiveStatus (/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/client-interceptors.ts:462:34),     at Object.onReceiveStatus (/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/client-interceptors.ts:424:48),     at /home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/call-stream.ts:334:24,     at processTicksAndRejections (internal/process/task_queues.js:77:11)]
```



After this changes:

```json
{
    "code": 200,
    "result": {
        "record_count": 4,
        "next_page_token": "",
        "records": [
            {
                "value": "IN",
                "name": "Invalid",
                "description": ""
            },
            {
                "value": "CL",
                "name": "Closed",
                "description": ""
            },
            {
                "value": "CO",
                "name": "Completed",
                "description": ""
            },
            {
                "value": "VO",
                "name": "Voided",
                "description": ""
            }
        ]
    }
}
```

