### PR TITLE
fix: Convert resource reference.

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "license": "MIT",
   "dependencies": {
     "@2fd/graphdoc": "^2.4.0",
-    "@adempiere/grpc-api": "4.5.6",
+    "@adempiere/grpc-api": "4.5.8",
     "@adempiere/grpc-web-store-api": "1.5.7",
     "@elastic/elasticsearch": "7.14.0",
     "@google-cloud/storage": "^3.0.3",
@@ -108,7 +108,7 @@
     "request-promise-native": "^1.0.5",
     "resource-router-middleware": "^0.6.0",
     "semver": "^6.3.0",
-    "sharp": "^0.23.4",
+    "sharp": "0.32.2",
     "soap": "^0.25.0",
     "storefront-query-builder": "^1.0.0",
     "supertest": "^4.0.2",

--- a/src/modules/adempiere-api/api/extensions/adempiere/user-interface/component/resource.ts
+++ b/src/modules/adempiere-api/api/extensions/adempiere/user-interface/component/resource.ts
@@ -1,5 +1,5 @@
 /************************************************************************************
- * Copyright (C) 2012-2023 E.R.P. Consultores y Asociados, C.A.                     *
+ * Copyright (C) 2018-2023 E.R.P. Consultores y Asociados, C.A.                     *
  * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com                     *
  * This program is free software: you can redistribute it and/or modify             *
  * it under the terms of the GNU General Public License as published by             *
@@ -14,17 +14,17 @@
  ************************************************************************************/
 
 import { Router } from 'express';
-import fs from 'fs';
-import multer from 'multer';
 import { ExtensionAPIFunctionParameter } from '@storefront-api/lib/module';
+
+import os from 'os'
+import fs from 'fs';
+import path from 'path'
+import multer from 'multer';
 
 import {
   convertAttachmentFromGRPC,
   convertResourceReferenceFromGRPC
 } from '@adempiere/grpc-api/lib/convertBaseDataType';
-
-const os = require('os');
-const path = require('path');
 
 function getCompleteFileName (fileName) {
   return path.join(os.tmpdir(), fileName);
@@ -129,7 +129,7 @@ module.exports = ({ config }: ExtensionAPIFunctionParameter) => {
         if (response) {
           res.json({
             code: 200,
-            result: response
+            result: convertResourceReferenceFromGRPC(response)
           });
         } else if (err) {
           if (fs.existsSync(completeName)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,10 +24,10 @@
     striptags "^3.0.1"
     word-wrap "^1.2.1"
 
-"@adempiere/grpc-api@4.5.6":
-  version "4.5.6"
-  resolved "https://registry.yarnpkg.com/@adempiere/grpc-api/-/grpc-api-4.5.6.tgz#ee8c14304fbd369d230bb0ade57eaba90985575c"
-  integrity sha512-xaKECYOrPNkHir3LA0L0cwnoVCOwDNz7vGRvraaV8jzMkPY80R1FECkh0ybK1cQeRXTil/u7c27L91ViKrTIUg==
+"@adempiere/grpc-api@4.5.8":
+  version "4.5.8"
+  resolved "https://registry.yarnpkg.com/@adempiere/grpc-api/-/grpc-api-4.5.8.tgz#28267c683457e0c553fa883eb888cc53ab739027"
+  integrity sha512-7bm+6D8Zb/9A3jL3Nbs7yktlQecsOnDYab+UnYOHZVBs8vvynUkzotmHT4ZbNmV7PFzKnDX4sOxUcBf+4W5Bzw==
   dependencies:
     "@grpc/grpc-js" "1.8.14"
     google-protobuf "3.21.2"
@@ -4072,6 +4072,11 @@ axios@^0.19.0:
   dependencies:
     follow-redirects "1.5.10"
 
+b4a@^1.6.4:
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.6.4.tgz#ef1c1422cae5ce6535ec191baeed7567443f36c9"
+  integrity sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw==
+
 babel-jest@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-24.9.0.tgz#3fc327cb8467b89d14d7bc70e315104a783ccd54"
@@ -5153,6 +5158,14 @@ color-string@^1.5.2, color-string@^1.6.0:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
 
+color-string@^1.9.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
+  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
 color@3.0.x:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/color/-/color-3.0.0.tgz#d920b4328d534a3ac8295d68f7bd4ba6c427be9a"
@@ -5168,6 +5181,14 @@ color@^3.0.0, color@^3.1.2:
   dependencies:
     color-convert "^1.9.3"
     color-string "^1.6.0"
+
+color@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/color/-/color-4.2.3.tgz#d781ecb5e57224ee43ea9627560107c0e0c6463a"
+  integrity sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==
+  dependencies:
+    color-convert "^2.0.1"
+    color-string "^1.9.0"
 
 colorette@^1.2.1, colorette@^1.2.2, colorette@^1.3.0:
   version "1.3.0"
@@ -6089,6 +6110,13 @@ decompress-response@^4.2.0:
   dependencies:
     mimic-response "^2.0.0"
 
+decompress-response@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
+  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
+  dependencies:
+    mimic-response "^3.1.0"
+
 dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
@@ -6259,6 +6287,11 @@ detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
+
+detect-libc@^2.0.0, detect-libc@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.1.tgz#e1897aa88fa6ad197862937fbc0441ef352ee0cd"
+  integrity sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==
 
 detect-newline@^2.1.0:
   version "2.1.0"
@@ -7317,6 +7350,11 @@ fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-fifo@^1.1.0, fast-fifo@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/fast-fifo/-/fast-fifo-1.3.0.tgz#03e381bcbfb29932d7c3afde6e15e83e05ab4d8b"
+  integrity sha512-IgfweLvEpwyA4WgiQe9Nx6VV2QkML2NkvZnk1oKnIzXgXdWxuhF7zw4DvLTPZJn6PIUneiAXPF24QmoEqHTjyw==
 
 fast-glob@^2.2.6:
   version "2.2.7"
@@ -11197,6 +11235,11 @@ mimic-response@^2.0.0:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
   integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
 
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
+
 min-document@^2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
@@ -11603,6 +11646,18 @@ node-abi@^2.7.0:
   integrity sha512-g6bZh3YCKQRdwuO/tSZZYJAw622SjsRfJ2X0Iy4sSOHZ34/sPPdVBn8fev2tj7njzLwuqPw9uMtGsGkO5kIQvg==
   dependencies:
     semver "^5.4.1"
+
+node-abi@^3.3.0:
+  version "3.45.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.45.0.tgz#f568f163a3bfca5aacfce1fbeee1fa2cc98441f5"
+  integrity sha512-iwXuFrMAcFVi/ZoZiqq8BzAdsLw9kxDfTC0HMyjXfSL/6CSDAGD5UmR7azrAgWV1zKYq7dUUMj4owusBWKLsiQ==
+  dependencies:
+    semver "^7.3.5"
+
+node-addon-api@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-6.1.0.tgz#ac8470034e58e67d0c6f1204a18ae6995d9c0d76"
+  integrity sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==
 
 node-fetch-npm@^2.0.2:
   version "2.0.4"
@@ -13104,6 +13159,24 @@ prebuild-install@^5.3.3:
     tunnel-agent "^0.6.0"
     which-pm-runs "^1.0.0"
 
+prebuild-install@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.1.tgz#de97d5b34a70a0c81334fd24641f2a1702352e45"
+  integrity sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==
+  dependencies:
+    detect-libc "^2.0.0"
+    expand-template "^2.0.3"
+    github-from-package "0.0.0"
+    minimist "^1.2.3"
+    mkdirp-classic "^0.5.3"
+    napi-build-utils "^1.0.1"
+    node-abi "^3.3.0"
+    pump "^3.0.0"
+    rc "^1.2.7"
+    simple-get "^4.0.0"
+    tar-fs "^2.0.0"
+    tunnel-agent "^0.6.0"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -13529,6 +13602,11 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+queue-tick@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/queue-tick/-/queue-tick-1.0.1.tgz#f6f07ac82c1fd60f82e098b417a80e52f1f4c142"
+  integrity sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==
 
 quick-lru@^1.0.0:
   version "1.1.0"
@@ -14439,6 +14517,13 @@ semver@^7.3.2, semver@^7.3.4:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.3.5, semver@^7.5.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  dependencies:
+    lru-cache "^6.0.0"
+
 send@0.17.1:
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"
@@ -14545,6 +14630,20 @@ shallow-clone@^3.0.0:
   dependencies:
     kind-of "^6.0.2"
 
+sharp@0.32.2:
+  version "0.32.2"
+  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.32.2.tgz#c35e065f8810cf0d8f3dee26fc5156127caca1ec"
+  integrity sha512-e4hyWKtU7ks/rLmoPys476zhpQnLqPJopz4+5b6OPeyJfvCTInAp0pe5tGhstjsNdUvDLrUVGEwevewYdZM8Eg==
+  dependencies:
+    color "^4.2.3"
+    detect-libc "^2.0.1"
+    node-addon-api "^6.1.0"
+    prebuild-install "^7.1.1"
+    semver "^7.5.4"
+    simple-get "^4.0.1"
+    tar-fs "^3.0.4"
+    tunnel-agent "^0.6.0"
+
 sharp@^0.23.4:
   version "0.23.4"
   resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.23.4.tgz#ca36067cb6ff7067fa6c77b01651cb9a890f8eb3"
@@ -14633,6 +14732,15 @@ simple-get@^3.0.3, simple-get@^3.1.0:
   integrity sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==
   dependencies:
     decompress-response "^4.2.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
+
+simple-get@^4.0.0, simple-get@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.1.tgz#4a39db549287c979d352112fa03fd99fd6bc3543"
+  integrity sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==
+  dependencies:
+    decompress-response "^6.0.0"
     once "^1.3.1"
     simple-concat "^1.0.0"
 
@@ -15110,6 +15218,14 @@ streamsearch@^1.1.0:
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
+streamx@^2.15.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/streamx/-/streamx-2.15.0.tgz#f58c92e6f726b5390dcabd6dd9094d29a854d698"
+  integrity sha512-HcxY6ncGjjklGs1xsP1aR71INYcsXFJet5CU1CHqihQ2J5nOsbd4OjgjHO42w/4QNv9gZb3BueV+Vxok5pLEXg==
+  dependencies:
+    fast-fifo "^1.1.0"
+    queue-tick "^1.0.1"
+
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
@@ -15504,6 +15620,15 @@ tar-fs@^2.0.0:
     pump "^3.0.0"
     tar-stream "^2.1.4"
 
+tar-fs@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.0.4.tgz#a21dc60a2d5d9f55e0089ccd78124f1d3771dbbf"
+  integrity sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==
+  dependencies:
+    mkdirp-classic "^0.5.2"
+    pump "^3.0.0"
+    tar-stream "^3.1.5"
+
 tar-stream@^2.1.4:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
@@ -15514,6 +15639,15 @@ tar-stream@^2.1.4:
     fs-constants "^1.0.0"
     inherits "^2.0.3"
     readable-stream "^3.1.1"
+
+tar-stream@^3.1.5:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-3.1.6.tgz#6520607b55a06f4a2e2e04db360ba7d338cc5bab"
+  integrity sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==
+  dependencies:
+    b4a "^1.6.4"
+    fast-fifo "^1.2.0"
+    streamx "^2.15.0"
 
 tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
   version "4.4.19"


### PR DESCRIPTION

#### Before this changes

![imagen](https://github.com/solop-develop/gRPC-API/assets/20288327/a7d14af8-9511-48d3-8fac-9598f8335d53)

```bash
error: uncaughtException: convertBaseDataType.getDecimalFromGRPC is not a function date=Thu Jul 13 2023 13:53:12 GMT-0400 (hora de Venezuela), pid=50187, uid=1000, gid=1000, cwd=/home/edwin/workspace/solop/proxy-adempiere-api, execPath=/home/edwin/.nvm/versions/node/v14.21.2/bin/node, version=v14.21.2, argv=[/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/.bin/ts-node, /home/edwin/workspace/solop/proxy-adempiere-api/src], rss=389304320, heapTotal=277286912, heapUsed=261712416, external=3318364, arrayBuffers=904393, loadavg=[1.23, 0.85, 0.76], uptime=14006.72, trace=[column=40, file=/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/lib/convertBaseDataType.js, function=Object.convertResourceReferenceFromGRPC, line=312, method=convertResourceReferenceFromGRPC, native=false, column=38, file=/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/lib/convertBaseDataType.js, function=null, line=298, method=null, native=false, column=null, file=null, function=Array.map, line=null, method=map, native=false, column=83, file=/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/lib/convertBaseDataType.js, function=Object.convertAttachmentFromGRPC, line=297, method=convertAttachmentFromGRPC, native=false, column=21, file=/home/edwin/workspace/solop/proxy-adempiere-api/src/modules/adempiere-api/api/extensions/adempiere/user-interface/component/resource.ts, function=Object.callback, line=102, method=callback, native=false, column=28, file=/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/client.ts, function=Object.onReceiveStatus, line=352, method=onReceiveStatus, native=false, column=34, file=/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/client-interceptors.ts, function=Object.onReceiveStatus, line=455, method=onReceiveStatus, native=false, column=48, file=/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/client-interceptors.ts, function=Object.onReceiveStatus, line=417, method=onReceiveStatus, native=false, column=24, file=/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/resolving-call.ts, function=null, line=111, method=null, native=false, column=11, file=internal/process/task_queues.js, function=processTicksAndRejections, line=77, method=null, native=false], stack=[TypeError: convertBaseDataType.getDecimalFromGRPC is not a function,     at Object.convertResourceReferenceFromGRPC (/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/lib/convertBaseDataType.js:312:40),     at /home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/lib/convertBaseDataType.js:298:38,     at Array.map (<anonymous>),     at Object.convertAttachmentFromGRPC (/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/lib/convertBaseDataType.js:297:83),     at Object.callback (/home/edwin/workspace/solop/proxy-adempiere-api/src/modules/adempiere-api/api/extensions/adempiere/user-interface/component/resource.ts:102:21),     at Object.onReceiveStatus (/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/client.ts:352:28),     at Object.onReceiveStatus (/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/client-interceptors.ts:455:34),     at Object.onReceiveStatus (/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/client-interceptors.ts:417:48),     at /home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/resolving-call.ts:111:24,     at processTicksAndRejections (internal/process/task_queues.js:77:11)]

```

#### After this changes

https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/27ba4510-b4ff-4014-9799-42417e796219

```json
{
	"code": 200,
	"result": {
		"resource_uuid": "e49600f2-1e3e-4a62-9ce7-8a68bf2bdd2a",
		"file_name": "e49600f2-1e3e-4a62-9ce7-8a68bf2bdd2a-AccountingUS.csv",
		"file_size": 354,
		"description": "",
		"text_msg": "",
		"content_type": "text/csv"
	}
}
```
