### PR TITLE
fix: Get RMA Lines List.

### DIFF
--- a/src/modules/adempiere-api/api/extensions/adempiere/form/addons/point-of-sales/pointOfSalesFromGRPC.ts
+++ b/src/modules/adempiere-api/api/extensions/adempiere/form/addons/point-of-sales/pointOfSalesFromGRPC.ts
@@ -370,6 +370,6 @@ export function getRMALineFromGRPC (rmaLineToConvert) {
     product_uom: getProductConversionFromGRPC(
       rmaLineToConvert.getProductUom()
     ),
-    source_order_line_id: rmaLineToConvert.getSourceRmaLineId()
+    source_order_line_id: rmaLineToConvert.getSourceOrderLineId()
   };
 }

--- a/src/modules/adempiere-api/api/extensions/adempiere/form/addons/point-of-sales/return-material/line.ts
+++ b/src/modules/adempiere-api/api/extensions/adempiere/form/addons/point-of-sales/return-material/line.ts
@@ -39,7 +39,13 @@ module.exports = ({ config }: ExtensionAPIFunctionParameter) => {
         if (response) {
           res.json({
             code: 200,
-            result: getRMALineFromGRPC(response)
+            result: {
+              record_count: response.getRecordCount(),
+              records: response.getRmaLinesList().map(rmaLine => {
+                return getRMALineFromGRPC(rmaLine);
+              }),
+              next_page_token: response.getNextPageToken()
+            }
           });
         } else if (err) {
           res.json({


### PR DESCRIPTION


```log
error: uncaughtException: rmaLineToConvert.getSourceRmaLineId is not a function date=Thu Aug 31 2023 18:16:25 GMT-0400 (hora de Venezuela), pid=218192, uid=1000, gid=1000, cwd=/home/edwin/workspace/solop/proxy-adempiere-api, execPath=/home/edwin/.nvm/versions/node/v14.21.2/bin/node, version=v14.21.2, argv=[/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/.bin/ts-node, /home/edwin/workspace/solop/proxy-adempiere-api/src], rss=768540672, heapTotal=662896640, heapUsed=626744304, external=2760234, arrayBuffers=347392, loadavg=[3.39, 2.74, 2.79], uptime=42499.28, trace=[column=44, file=/home/edwin/workspace/solop/proxy-adempiere-api/src/modules/adempiere-api/api/extensions/adempiere/form/addons/point-of-sales/pointOfSalesFromGRPC.ts, function=Object.getRMALineFromGRPC, line=375, method=getRMALineFromGRPC, native=false, column=24, file=/home/edwin/workspace/solop/proxy-adempiere-api/src/modules/adempiere-api/api/extensions/adempiere/form/addons/point-of-sales/return-material/line.ts, function=null, line=45, method=null, native=false, column=null, file=null, function=Array.map, line=null, method=map, native=false, column=51, file=/home/edwin/workspace/solop/proxy-adempiere-api/src/modules/adempiere-api/api/extensions/adempiere/form/addons/point-of-sales/return-material/line.ts, function=Object.callback, line=44, method=callback, native=false, column=28, file=/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/client.ts, function=Object.onReceiveStatus, line=352, method=onReceiveStatus, native=false, column=34, file=/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/client-interceptors.ts, function=Object.onReceiveStatus, line=454, method=onReceiveStatus, native=false, column=48, file=/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/client-interceptors.ts, function=Object.onReceiveStatus, line=416, method=onReceiveStatus, native=false, column=24, file=/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/resolving-call.ts, function=null, line=111, method=null, native=false, column=11, file=internal/process/task_queues.js, function=processTicksAndRejections, line=77, method=null, native=false], stack=[TypeError: rmaLineToConvert.getSourceRmaLineId is not a function,     at Object.getRMALineFromGRPC (/home/edwin/workspace/solop/proxy-adempiere-api/src/modules/adempiere-api/api/extensions/adempiere/form/addons/point-of-sales/pointOfSalesFromGRPC.ts:375:44),     at /home/edwin/workspace/solop/proxy-adempiere-api/src/modules/adempiere-api/api/extensions/adempiere/form/addons/point-of-sales/return-material/line.ts:45:24,     at Array.map (<anonymous>),     at Object.callback (/home/edwin/workspace/solop/proxy-adempiere-api/src/modules/adempiere-api/api/extensions/adempiere/form/addons/point-of-sales/return-material/line.ts:44:51),     at Object.onReceiveStatus (/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/client.ts:352:28),     at Object.onReceiveStatus (/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/client-interceptors.ts:454:34),     at Object.onReceiveStatus (/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/client-interceptors.ts:416:48),     at /home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/resolving-call.ts:111:24,     at processTicksAndRejections (internal/process/task_queues.js:77:11)]

```
