### PR TITLE
fix: Yarn version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "engines": {
     "node": ">=10"
   },
-  "packageManager": "yarn@1.22.19",
   "scripts": {
     "ci": "yarn install --frozen-lockfile",
     "dev": "nodemon",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "main": "dist",
   "engineStrict": true,
   "engines": {
-    "node": ">=10",
-    "yarn": "=1.22.19"
+    "node": ">=10"
   },
   "packageManager": "yarn@1.22.19",
   "scripts": {


### PR DESCRIPTION

With alpine container.

```log
proxy_1  error proxy-adempiere-api@2.4.9: The engine "yarn" is incompatible with this module. Expected version "=1.22.19". Got "1.22.5"
```